### PR TITLE
Corrected crash on diagnostic calls

### DIFF
--- a/myhome-light.js
+++ b/myhome-light.js
@@ -11,17 +11,17 @@ module.exports = function(RED) {
       var payload = {}
 
       // check if message is a status update
-      if(new RegExp('\\*1\\*(\\d+)\\*(' + config.lightid + '|0)##').test(packet) || // simple light status
-         new RegExp('\\*#1\\*' + config.lightid + '\\*1\\*(\\d+)\\*(\\d+)##').test(packet)) {  // dimmer updates
+      if(new RegExp('^\\*1\\*(\\d+)\\*(' + config.lightid + '|0)##').test(packet) || // simple light status
+         new RegExp('^\\*#1\\*' + config.lightid + '\\*1\\*(\\d+)\\*(\\d+)##').test(packet)) {  // dimmer updates
 
         if(packet[1] == '#') {
-          var m = packet.match('\\*#1\\*' + config.lightid + '\\*1\\*(\\d+)\\*4##'),
+          var m = packet.match('^\\*#1\\*' + config.lightid + '\\*1\\*(\\d+)\\*4##'),
               what = parseInt(m[1])
 
           payload.state = 'ON'
           payload.brightness = (what - 100)
         } else {
-          var m = packet.match('\\*1\\*(\\d+)\\*(' + config.lightid + '|0)##'),
+          var m = packet.match('^\\*1\\*(\\d+)\\*(' + config.lightid + '|0)##'),
               what = parseInt(m[1])
 
           if((what == 0) || (what == 1)) {


### PR DESCRIPTION
Corrected #6 : the problem was caused with diagnostics call (WHO = 1001, 1004 or 1013) for which responses are quite long...
The regex used to filter could then find a part (within the command) which looked like light updates.
ex: *#1001*0*30*1*400*0##
where the end of it (1*400*0##) is similar to a light/switch change, which it is not...
Changed to ensure the regexp is tested at the start of the string and not in the middle of it.