### PR TITLE
Corrected crash on diagnostic calls

### DIFF
--- a/myhome-switch.js
+++ b/myhome-switch.js
@@ -11,8 +11,8 @@ module.exports = function(RED) {
       var payload = ''
 
       // check if message is a status update
-      if(new RegExp('\\*1\\*(\\d+)\\*(' + config.switchid + '|0)##').test(packet)) {
-          var m = packet.match('\\*1\\*(\\d+)\\*(' + config.switchid + '|0)##'),
+      if(new RegExp('^\\*1\\*(\\d+)\\*(' + config.switchid + '|0)##').test(packet)) {
+          var m = packet.match('^\\*1\\*(\\d+)\\*(' + config.switchid + '|0)##'),
               what = parseInt(m[1])
           if (m == undefined) {
             node.error('failed parsing OWN packet: ' + packet)


### PR DESCRIPTION
Corrected #6  : the problem was caused with diagnostics call (WHO = 1001, 1004 or 1013) for which responses are quite long...
The regex used to filter could then find a part (within the command) which looked like light updates.
ex: *#1001*0*30*1*400*0##
where the end of it (1*400*0##) is similar to a light/switch change, which it is not...
Changed to ensure the regexp is tested at the start of the string and not in the middle of it.