### PR TITLE
V2.3.3 energy updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # node-red-contrib-myhome-bticino-v2
 ## Version history
-### v2.3.2 (latest available) - 01/2024
-- **MH Temperature Central Unit** :
+### v2.3.3 (latest available) - 03/2024
+- **MH Energy**
+	- ***Improvement*** : the provided payload can now specify another scope than the one configured on node which has to be queried. Supported values on 'payload.meterscope' are 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.
+### v2.3.2 - 01/2024
+- **MH Temperature Central Unit**
 	- ***Improvement*** : a new option was added on node to ask for current Central status when node is loaded (i.e. on deploy or when Node-RED server starts). Data collection will trigger flows accordingly, which can be used to (re)set depending values in your flow on load. It is enabled by default for new installs.
-- **MH Temperature Zone** :
+- **MH Temperature Zone**
 	- ***Improvement*** : a new option was added on node to ask for current Zone status when node is loaded (i.e. on deploy or when Node-RED server starts). Data collection will trigger flows accordingly, which can be used to (re)set depending values in your flow on load. It is enabled by default for new installs.
   - ***Documentation fix*** : corrected '.state' output content description
 ### v2.3.1 - 08/2023
@@ -25,11 +28,11 @@
   - ***Improvement*** : when changing additional outputs (re-order / insert / delete), the linked output descriptions and wires are now automatically updated accordingly to preserve existing flow wiring configuration.
   - ***Improvement*** : improved how outputs are described (when mousing over it in Node-RED interface)
   - ***Bug fix*** : label of 'Short press' was not updated correctly based on 'CEN/CEN+' node type defined
-- **MH Temperature Central Unit** :
+- **MH Temperature Central Unit**
   - ***Bug fix*** : corrected secondary payload info displayed (when mousing over it in Node-RED interface)
-- **MH Temperature Zone** :
+- **MH Temperature Zone**
   - ***Bug fix*** : corrected secondary payload info displayed (when mousing over it in Node-RED interface)
-- **MH Inject** :
+- **MH Inject**
   - ***Improvement*** : added an option to allow overriding specified delay (in ms) which is applied before sending a new command to the BUS. Incoming message 'msg.rate' -when available- is then used as new delay.
 - **MH Energy** : ***New node type***
   Added support for Energy Management.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,9 @@ Control Bticino / Legrand MyHome&#8482; components from Node-RED : node-red-cont
 		- **`*#1*16##`** to ask for status about light **16**, receiving as a response **`*1*1*16##`** when is ON or **`*1*0*16##`** when is OFF
 
 ## 2. Version history
-### v2.3.2 (latest available) - 01/2024
-- **MH Temperature Central Unit** :
-	- ***Improvement*** : a new option was added on node to ask for current Central status when node is loaded (i.e. on deploy or when Node-RED server starts). Data collection will trigger flows accordingly, which can be used to (re)set depending values in your flow on load. It is enabled by default for new installs.
-- **MH Temperature Zone** :
-	- ***Improvement*** : a new option was added on node to ask for current Zone status when node is loaded (i.e. on deploy or when Node-RED server starts). Data collection will trigger flows accordingly, which can be used to (re)set depending values in your flow on load. It is enabled by default for new installs.
-  - ***Documentation fix*** : corrected '.state' output content description
+### v2.3.3 (latest available) - 03/2024
+- **MH Energy**
+	- ***Improvement*** : the provided payload can now specify another scope than the one configured on node which has to be queried. Supported values on 'payload.meterscope' are 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.
 
 The **complete version history** is available in `CHANGELOG.md` file included in npm package or using this link to [GitHub repository](https://github.com/FredBlo/node-red-contrib-myhome-bticino-v2/blob/main/CHANGELOG.md)
 

--- a/locales/en-US/myhome-energy.html
+++ b/locales/en-US/myhome-energy.html
@@ -38,6 +38,8 @@
       </li>
       <li>An Object
         <ul>
+          <li> <code>payload.meterscope</code> <em>[string]</em> when set, overrides the configured node's scope.
+            <br>Can be : 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.</li>
           <li> <code>payload.metered_From</code> <em>[string]</em> value must be convertible to a valid date (+time); if not defaults to current date-time.
             <br>Defines from when meter info must be collected</li>
           <li> <code>payload.metered_To</code> <em>[string]</em> value must be convertible to a valid date (+time); if not defaults to <code>payload.metered_From</code>.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-myhome-bticino-v2",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Control Bticino / Legrand MyHome components from Node-RED",
   "homepage": "https://github.com/FredBlo/node-red-contrib-myhome-bticino-v2#readme",
   "repository": {


### PR DESCRIPTION
### v2.3.3 (latest available) - 03/2024
- **MH Energy**
	- ***Improvement*** : the provided payload can now specify another scope than the one configured on node which has to be queried. Supported values on 'payload.meterscope' are 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.