### PR TITLE
V2.4.0 : new outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # node-red-contrib-myhome-bticino-v2
 ## Version history
 ### v2.4.0 (latest available) - 01/2025
+- **MH Monitoring**
+  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.ownFamilyName` and `.gateway` (object)
 - **MH Light**
   - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway` (object)
 - **MH Shutter**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # node-red-contrib-myhome-bticino-v2
 ## Version history
+### v2.4.0 (latest available) - 01/2025
+- **MH Light**
+  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway` (object)
+- **MH Shutter**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.shutterid`, `.isgroup` and `.gateway` (object)
+- **MH Scenario**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.scenarioid`, `.scenariotype` and `.gateway` (object)
+- **MH Temperature Central Unit**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic` and `.gateway` (object)
+- **MH Temperature Zone**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.zoneid` and `.gateway` (object)
+- **MH Energy** :
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.meterid`, `.metertype`, `.meterscope` and `.gateway` (object)
 ### v2.3.3 (latest available) - 03/2024
 - **MH Energy**
 	- ***Improvement*** : the provided payload can now specify another scope than the one configured on node which has to be queried. Supported values on 'payload.meterscope' are 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ### v2.4.0 (latest available) - 01/2025
 - **MH Monitoring**
   - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.ownFamilyName` and `.gateway` (object)
-  - ***Improvement*** : node has a second output which provides a structured payload object with analyzed information based on BUS received content, as it would be output by a specialized light, shutter,... node. It makes the monitoring node usable as a sort of 'universal node' : all events of one or multiple family types can be processed from a single monitoring node instead of having to add a node for each light, shutter,... point. This is currently only supported for **lights**, **shutters** and **scenario**.
+  - ***Improvement*** : node has a second output which provides a structured payload object with analyzed information based on BUS received content, as it would be output by a specialized light, shutter,... node. It makes the monitoring node usable as a sort of 'universal node' : all events of one or multiple family types can be processed from a single monitoring node instead of having to add a node for each light, shutter,... point.
+  This currently supports (see Monitoring node documentation for full detailed payload content):
+    - **Lights** : any light point / group call
+    - **Shutters** : any shutter point / group call
+    - **Temperature** : only outputs current temperature update from a thermo zone
+    - **Scenario** : outputs any button press for CEN/CEN+
+    - **Energy** : only outputs current consumption (instant) of any meter
 - **MH Light**
   - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway` (object)
 - **MH Shutter**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,21 @@
   This currently supports (see Monitoring node documentation for full detailed payload content):
     - **Lights** : any light point / group call
     - **Shutters** : any shutter point / group call
-    - **Temperature** : only outputs current temperature update from a thermo zone
+    - **Temperature** : only outputs current temperature update for any zone
     - **Scenario** : outputs any button press for CEN/CEN+
     - **Energy** : only outputs current consumption (instant) of any meter
 - **MH Light**
-  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway` (object)
+  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway`*[object]*
 - **MH Shutter**
-	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.shutterid`, `.isgroup` and `.gateway` (object)
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.shutterid`, `.isgroup` and `.gateway`*[object]*
 - **MH Scenario**
-	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.scenarioid`, `.scenariotype` and `.gateway` (object)
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.scenarioid`, `.scenariotype` and `.gateway`*[object]*
 - **MH Temperature Central Unit**
-	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic` and `.gateway` (object)
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic` and `.gateway` *[object]*
 - **MH Temperature Zone**
-	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.zoneid` and `.gateway` (object)
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.zoneid` and `.gateway` *[object]*
 - **MH Energy** :
-	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.meterid`, `.metertype`, `.meterscope` and `.gateway` (object)
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.meterid`, `.metertype`, `.meterscope` and `.gateway` *[object]*
 ### v2.3.3 (latest available) - 03/2024
 - **MH Energy**
 	- ***Improvement*** : the provided payload can now specify another scope than the one configured on node which has to be queried. Supported values on 'payload.meterscope' are 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v2.4.0 (latest available) - 01/2025
 - **MH Monitoring**
   - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.ownFamilyName` and `.gateway` (object)
+  - ***Improvement*** : node has a second output which provides a structured payload object with analyzed information based on BUS received content, as it would be output by a specialized light, shutter,... node. It makes the monitoring node usable as a sort of 'universal node' : all events of one or multiple family types can be processed from a single monitoring node instead of having to add a node for each light, shutter,... point. This is currently only supported for **lights**, **shutters** and **scenario**.
 - **MH Light**
   - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway` (object)
 - **MH Shutter**

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Control Bticino / Legrand MyHome&#8482; components from Node-RED : node-red-cont
 		- **`*#1*16##`** to ask for status about light **16**, receiving as a response **`*1*1*16##`** when is ON or **`*1*0*16##`** when is OFF
 
 ## 2. Version history
-### v2.3.3 (latest available) - 03/2024
-- **MH Energy**
-	- ***Improvement*** : the provided payload can now specify another scope than the one configured on node which has to be queried. Supported values on 'payload.meterscope' are 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin'.
+### v2.4.0 (latest available) - 01/2025
+	TODO --> Recopy from CHANHGELOG.md
 
 The **complete version history** is available in `CHANGELOG.md` file included in npm package or using this link to [GitHub repository](https://github.com/FredBlo/node-red-contrib-myhome-bticino-v2/blob/main/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,27 @@ Control Bticino / Legrand MyHome&#8482; components from Node-RED : node-red-cont
 
 ## 2. Version history
 ### v2.4.0 (latest available) - 01/2025
-	TODO --> Recopy from CHANHGELOG.md
+- **MH Monitoring**
+  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.ownFamilyName` and `.gateway` (object)
+  - ***Improvement*** : node has a second output which provides a structured payload object with analyzed information based on BUS received content, as it would be output by a specialized light, shutter,... node. It makes the monitoring node usable as a sort of 'universal node' : all events of one or multiple family types can be processed from a single monitoring node instead of having to add a node for each light, shutter,... point.
+  This currently supports (see Monitoring node documentation for full detailed payload content):
+    - **Lights** : any light point / group call
+    - **Shutters** : any shutter point / group call
+    - **Temperature** : only outputs current temperature update for any zone
+    - **Scenario** : outputs any button press for CEN/CEN+
+    - **Energy** : only outputs current consumption (instant) of any meter
+- **MH Light**
+  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway`*[object]*
+- **MH Shutter**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.shutterid`, `.isgroup` and `.gateway`*[object]*
+- **MH Scenario**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.scenarioid`, `.scenariotype` and `.gateway`*[object]*
+- **MH Temperature Central Unit**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic` and `.gateway` *[object]*
+- **MH Temperature Zone**
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.zoneid` and `.gateway` *[object]*
+- **MH Energy** :
+	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.meterid`, `.metertype`, `.meterscope` and `.gateway` *[object]*
 
 The **complete version history** is available in `CHANGELOG.md` file included in npm package or using this link to [GitHub repository](https://github.com/FredBlo/node-red-contrib-myhome-bticino-v2/blob/main/CHANGELOG.md)
 

--- a/locales/en-US/myhome-energy.html
+++ b/locales/en-US/myhome-energy.html
@@ -74,4 +74,20 @@
     </ul>
 
   <p>The <strong>secondary output</strong> can be configured to better suits the needs of other node types you use without having to use an extra function/switch node for each connector.</p>
+
+  <p>
+    <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+  </p>
+  <p>
+    The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+  </p>
+  <ul>
+    <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+    <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
+    <li> <code>mh_nodeConfigInfo.meterid</code> <em>[string]</em> : meter ID</li>
+    <li> <code>mh_nodeConfigInfo.metertype</code> <em>[string]</em> : type of meter (can be 'meter' or 'actuator')</li>
+    <li> <code>mh_nodeConfigInfo.meterscope</code> <em>[string]</em> : scope set (can be 'instant', 'day_uptonow', 'day', 'hour', 'month_uptonow', 'month', 'sincebegin') </li>
+    <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+  </ul>
 </script>

--- a/locales/en-US/myhome-energy.html
+++ b/locales/en-US/myhome-energy.html
@@ -76,7 +76,7 @@
   <p>The <strong>secondary output</strong> can be configured to better suits the needs of other node types you use without having to use an extra function/switch node for each connector.</p>
 
   <p>
-    <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
     This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
   </p>
   <p>

--- a/locales/en-US/myhome-eventsession.html
+++ b/locales/en-US/myhome-eventsession.html
@@ -31,6 +31,15 @@
             <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
             <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
           </ul>
+          <li><strong>Scenario CEN/CEN+</strong> : payload object details :</li>
+            <ul>
+              <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol (ex: <em>'*25*24#14*287##'</em> means button 14 of scenario 87 finalized a long press)</li>
+              <li> <code>payload.buslevel</code> <em>[string]</em> : bus level ('private_riser', '01', '02', ... '15')</li>
+              <li> <code>payload.scenariotype</code> <em>[string]</em> value is 'CEN' or 'CEN+'</li>
+              <li> <code>payload.scenarioid</code> <em>[string]</em> the ID of scenario (for CEN is an A/P value, for CEN+ is [0-2047])</li>
+              <li> <code>payload.buttonID</code> <em>[string]</em> : the button which was pressed [00-31]</li>
+              <li> <code>payload.actionType</code> <em>[string]</em> : the action type (can be 'SHORT', 'LONG', 'LONG_ONGOING',...)</li>
+            </ul>
       </ul>
     <p>
       <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.

--- a/locales/en-US/myhome-eventsession.html
+++ b/locales/en-US/myhome-eventsession.html
@@ -37,7 +37,7 @@
           <ul>
             <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol</li>
             <li> <code>payload.zoneid</code> <em>[string]</em> the ID of zone [1-99])</li>
-            <li> <code>payload.state</code> <em>[number]</em> the current measured temperature</li>
+            <li> <code>payload.state</code> <em>[number]</em> the current measured temperature ()°C)</li>
           </ul>
         <li><strong>Scenario CEN/CEN+</strong> : payload object details :</li>
           <ul>

--- a/locales/en-US/myhome-eventsession.html
+++ b/locales/en-US/myhome-eventsession.html
@@ -10,5 +10,19 @@
     <p>(none)</p>
 
   <h3>Output</h3>
-    <p>The <strong>output</strong> is a <em>[string]</em> containing the OpenWebNet command read on the MyHome BUS.</p>
+    <p>The <strong>primary output</strong> is a <em>[string]</em> containing the OpenWebNet command read on the MyHome BUS.</p>
+    <p>The <strong>secondary output</strong> contains detailled analyzed information as if the node was working in 'universal mode' (i.e. processing all received BUS frames).</p>
+    <p>'Universal mode' is currently only supported for lights. TODO </p>
+    <p>
+      <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+      This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+    </p>
+    <p>
+      The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+    </p>
+    <ul>
+      <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+      <li> <code>mh_nodeConfigInfo.ownFamilyName</code> <em>[string]</em> : the OpenWebNet famaily name (such as 'OWN_LIGHTS', 'OWN_SCENARIO',...)</li>
+      <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+    </ul>
 </script>

--- a/locales/en-US/myhome-eventsession.html
+++ b/locales/en-US/myhome-eventsession.html
@@ -24,13 +24,13 @@
             <li> <code>payload.isgroup</code> <em>[boolean]</em> : group call (true) or single light point call (false)</li>
           </ul>
         <li><strong>Shutters</strong> : payload object details :</li>
-        TODO
-        TODO
-          <ul>
-            <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
-            <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
-            <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
-          </ul>
+            <ul>
+              <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol (ex: <em>'*2*2*25##'</em> means shutter 2.5 'close' action was started)</li>
+              <li> <code>payload.buslevel</code> <em>[string]</em> : bus level ('private_riser', '01', '02', ... '15')</li>
+              <li> <code>payload.state</code> <em>[string]</em> value is 'STOP', 'OPEN' or 'CLOSE'</li>
+              <li> <code>payload.shutterid</code> <em>[string]</em> : shutter ID</li>
+              <li> <code>payload.isgroup</code> <em>[boolean]</em> : group call (true) or single shutter point call (false)</li>
+            </ul>
           <li><strong>Scenario CEN/CEN+</strong> : payload object details :</li>
             <ul>
               <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol (ex: <em>'*25*24#14*287##'</em> means button 14 of scenario 87 finalized a long press)</li>

--- a/locales/en-US/myhome-eventsession.html
+++ b/locales/en-US/myhome-eventsession.html
@@ -12,9 +12,28 @@
   <h3>Output</h3>
     <p>The <strong>primary output</strong> is a <em>[string]</em> containing the OpenWebNet command read on the MyHome BUS.</p>
     <p>The <strong>secondary output</strong> contains detailled analyzed information as if the node was working in 'universal mode' (i.e. processing all received BUS frames).</p>
-    <p>'Universal mode' is currently only supported for lights. TODO </p>
+    <p>'Universal mode' is currently only supported for a few types :
+      <ul>
+        <li><strong>Lights</strong> : payload object details :</li>
+          <ul>
+            <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol (ex: <em>'*1*5*25##'</em> means load 2.5 was turned on at 50% brightness)</li>
+            <li> <code>payload.buslevel</code> <em>[string]</em> : bus level ('private_riser', '01', '02', ... '15')</li>
+            <li> <code>payload.state</code> <em>[string]</em> value is 'ON' or 'OFF'</li>
+            <li> <code>payload.brightness</code> <em>[integer]</em> represents current brightness percentage of the load. When non-dimmmable is 0 or 100. </li>
+            <li> <code>payload.lightid</code> <em>[string]</em> : light ID</li>
+            <li> <code>payload.isgroup</code> <em>[boolean]</em> : group call (true) or single light point call (false)</li>
+          </ul>
+        <li><strong>Shutters</strong> : payload object details :</li>
+        TODO
+        TODO
+          <ul>
+            <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
+            <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
+            <li> <code>payload.xxxx</code> <em>[string]</em> : xxxx</li>
+          </ul>
+      </ul>
     <p>
-      <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+      <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
       This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
     </p>
     <p>

--- a/locales/en-US/myhome-eventsession.html
+++ b/locales/en-US/myhome-eventsession.html
@@ -11,8 +11,10 @@
 
   <h3>Output</h3>
     <p>The <strong>primary output</strong> is a <em>[string]</em> containing the OpenWebNet command read on the MyHome BUS.</p>
-    <p>The <strong>secondary output</strong> contains detailled analyzed information as if the node was working in 'universal mode' (i.e. processing all received BUS frames).</p>
-    <p>'Universal mode' is currently only supported for a few types :
+    <p>
+      The <strong>secondary output</strong> contains detailled analyzed information as if the node was working in 'universal mode' (i.e. processing all received BUS frames).
+      Content of msg will vary based on family type :
+    </p>
       <ul>
         <li><strong>Lights</strong> : payload object details :</li>
           <ul>
@@ -31,15 +33,29 @@
               <li> <code>payload.shutterid</code> <em>[string]</em> : shutter ID</li>
               <li> <code>payload.isgroup</code> <em>[boolean]</em> : group call (true) or single shutter point call (false)</li>
             </ul>
-          <li><strong>Scenario CEN/CEN+</strong> : payload object details :</li>
-            <ul>
-              <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol (ex: <em>'*25*24#14*287##'</em> means button 14 of scenario 87 finalized a long press)</li>
-              <li> <code>payload.buslevel</code> <em>[string]</em> : bus level ('private_riser', '01', '02', ... '15')</li>
-              <li> <code>payload.scenariotype</code> <em>[string]</em> value is 'CEN' or 'CEN+'</li>
-              <li> <code>payload.scenarioid</code> <em>[string]</em> the ID of scenario (for CEN is an A/P value, for CEN+ is [0-2047])</li>
-              <li> <code>payload.buttonID</code> <em>[string]</em> : the button which was pressed [00-31]</li>
-              <li> <code>payload.actionType</code> <em>[string]</em> : the action type (can be 'SHORT', 'LONG', 'LONG_ONGOING',...)</li>
-            </ul>
+        <li><strong>Temperature</strong> : payload object details (only reads 'current temperature' of zone mode) :</li>
+          <ul>
+            <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol</li>
+            <li> <code>payload.zoneid</code> <em>[string]</em> the ID of zone [1-99])</li>
+            <li> <code>payload.state</code> <em>[number]</em> the current measured temperature</li>
+          </ul>
+        <li><strong>Scenario CEN/CEN+</strong> : payload object details :</li>
+          <ul>
+            <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol (ex: <em>'*25*24#14*287##'</em> means button 14 of scenario 87 finalized a long press)</li>
+            <li> <code>payload.buslevel</code> <em>[string]</em> : bus level ('private_riser', '01', '02', ... '15')</li>
+            <li> <code>payload.scenariotype</code> <em>[string]</em> value is 'CEN' or 'CEN+'</li>
+            <li> <code>payload.scenarioid</code> <em>[string]</em> the ID of scenario (for CEN is an A/P value, for CEN+ is [0-2047])</li>
+            <li> <code>payload.buttonID</code> <em>[string]</em> : the button which was pressed [00-31]</li>
+            <li> <code>payload.actionType</code> <em>[string]</em> : the action type (can be 'SHORT', 'LONG', 'LONG_ONGOING',...)</li>
+          </ul>
+        <li><strong>Energy management</strong> : payload object details (only reads 'instant' consumption mode) :</li>
+          <ul>
+            <li> <code>payload.command_received</code> <em>[string]</em> contains the command which was read in OpenWebNet protocol</li>
+            <li> <code>payload.metertype</code> <em>[string]</em> value is 'meter' or 'actuator''</li>
+            <li> <code>payload.meterscope</code> <em>[string]</em> is always 'instant' in universal mode</li>
+            <li> <code>payload.meterid</code> <em>[string]</em> : address (1 to 255) of the meter</li>
+            <li> <code>payload.metered_Power</code> <em>[integer]</em> : the instant power (W) measured</li>
+          </ul>
       </ul>
     <p>
       <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.

--- a/locales/en-US/myhome-light.html
+++ b/locales/en-US/myhome-light.html
@@ -85,7 +85,7 @@
       </li>
     </ul>
     <p>
-      <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+      <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
       This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
     </p>
     <p>

--- a/locales/en-US/myhome-light.html
+++ b/locales/en-US/myhome-light.html
@@ -84,4 +84,19 @@
         </ul>
       </li>
     </ul>
+    <p>
+      <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+      This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+    </p>
+    <p>
+      The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+    </p>
+    <ul>
+      <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+      <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
+      <li> <code>mh_nodeConfigInfo.buslevel</code> <em>[string]</em> : bus level (such as 'private_riser', '01', '02', ... '15')</li>
+      <li> <code>mh_nodeConfigInfo.lightid</code> <em>[string]</em> : light ID</li>
+      <li> <code>mh_nodeConfigInfo.isgroup</code> <em>[boolean]</em> : configured as group (true) or as single light point (false)</li>
+      <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+    </ul>
 </script>

--- a/locales/en-US/myhome-scenario.html
+++ b/locales/en-US/myhome-scenario.html
@@ -76,7 +76,7 @@
   </ul>
   <p>Any <strong>additional output</strong> defined is also a JSON object <code>msg.payload</code> having the same (direct) properties as a <code>payload.buttonsLastState_xx</code> object described above.</p>
   <p>
-    <strong>All outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    <strong>All outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
     This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
   </p>
   <p>

--- a/locales/en-US/myhome-scenario.html
+++ b/locales/en-US/myhome-scenario.html
@@ -75,4 +75,19 @@
     <li> <code>payload.command_failed</code> <em>[array of strings]</em> will contain the commands which were refused by the MyHome gateway, in OpenWebNet protocol</li>
   </ul>
   <p>Any <strong>additional output</strong> defined is also a JSON object <code>msg.payload</code> having the same (direct) properties as a <code>payload.buttonsLastState_xx</code> object described above.</p>
+  <p>
+    <strong>All outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+  </p>
+  <p>
+    The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+  </p>
+  <ul>
+    <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+    <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
+    <li> <code>mh_nodeConfigInfo.buslevel</code> <em>[string]</em> : bus level (such as 'private_riser', '01', '02', ... '15')</li>
+    <li> <code>mh_nodeConfigInfo.scenarioid</code> <em>[string]</em> : scenario ID</li>
+    <li> <code>mh_nodeConfigInfo.scenariotype</code> <em>[string]</em> : scenrio type (can be 'CEN' or 'CEN+'</li>
+    <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+  </ul>
 </script>

--- a/locales/en-US/myhome-shutter.html
+++ b/locales/en-US/myhome-shutter.html
@@ -72,7 +72,7 @@
       </li>
     </ul>
     <p>
-      <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+      <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
       This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
     </p>
     <p>

--- a/locales/en-US/myhome-shutter.html
+++ b/locales/en-US/myhome-shutter.html
@@ -71,5 +71,19 @@
         </ul>
       </li>
     </ul>
-
+    <p>
+      <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+      This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+    </p>
+    <p>
+      The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+    </p>
+    <ul>
+      <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+      <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
+      <li> <code>mh_nodeConfigInfo.buslevel</code> <em>[string]</em> : bus level (such as 'private_riser', '01', '02', ... '15')</li>
+      <li> <code>mh_nodeConfigInfo.shutterid</code> <em>[string]</em> : shutter ID</li>
+      <li> <code>mh_nodeConfigInfo.isgroup</code> <em>[boolean]</em> : configured as group (true) or as single shutter point (false)</li>
+      <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+    </ul>
 </script>

--- a/locales/en-US/myhome-thermo-central.html
+++ b/locales/en-US/myhome-thermo-central.html
@@ -77,25 +77,37 @@
     <br>
     <u>Samples:</u>
   </p>
-    <ul>
-      <li><strong>HUEMagic</strong> nodes support :
-        <ul>
-          <li><code>payload</code> being a boolean (true/false)</li>
-          <li><code>payload</code> being a JSON object where <code>.ON</code> is a boolean (true/false)</li>
-        </ul>
-      </li>
-      <li><strong>Homekit-bridge</strong> nodes support :
-        <ul>
-          <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
-        </ul>
-        <p>(see:&nbsp;<a title="homekit bridged" href="https://www.npmjs.com/package/node-red-contrib-homekit-bridged" target="_blank" rel="noopener">https://www.npmjs.com/package/node-red-contrib-homekit-bridged</a>) allow managing iOS Home App.</p>
-      </li>
-      <li><strong>MyHome</strong> nodes support :
-        <ul>
-          <li><code>payload</code> being either a boolean (true/false) or a string (ON/OFF/OPEN/CLOSE/...)</li>
-          <li><code>payload</code> being a JSON object where <code>.state</code> is a string (ON/OFF/OPEN/CLOSE/...)</li>
-          <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
-        </ul>
-      </li>
-    </ul>
+  <ul>
+    <li><strong>HUEMagic</strong> nodes support :
+      <ul>
+        <li><code>payload</code> being a boolean (true/false)</li>
+        <li><code>payload</code> being a JSON object where <code>.ON</code> is a boolean (true/false)</li>
+      </ul>
+    </li>
+    <li><strong>Homekit-bridge</strong> nodes support :
+      <ul>
+        <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
+      </ul>
+      <p>(see:&nbsp;<a title="homekit bridged" href="https://www.npmjs.com/package/node-red-contrib-homekit-bridged" target="_blank" rel="noopener">https://www.npmjs.com/package/node-red-contrib-homekit-bridged</a>) allow managing iOS Home App.</p>
+    </li>
+    <li><strong>MyHome</strong> nodes support :
+      <ul>
+        <li><code>payload</code> being either a boolean (true/false) or a string (ON/OFF/OPEN/CLOSE/...)</li>
+        <li><code>payload</code> being a JSON object where <code>.state</code> is a string (ON/OFF/OPEN/CLOSE/...)</li>
+        <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
+      </ul>
+    </li>
+  </ul>
+  <p>
+    <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+  </p>
+  <p>
+    The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+  </p>
+  <ul>
+    <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+    <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
+    <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+  </ul>
 </script>

--- a/locales/en-US/myhome-thermo-central.html
+++ b/locales/en-US/myhome-thermo-central.html
@@ -99,7 +99,7 @@
     </li>
   </ul>
   <p>
-    <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
     This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
   </p>
   <p>

--- a/locales/en-US/myhome-thermo-zone.html
+++ b/locales/en-US/myhome-thermo-zone.html
@@ -125,25 +125,38 @@
     <br>
     <u>Samples:</u>
   </p>
-    <ul>
-      <li><strong>HUEMagic</strong> nodes support :
-        <ul>
-          <li><code>payload</code> being a boolean (true/false)</li>
-          <li><code>payload</code> being a JSON object where <code>.ON</code> is a boolean (true/false)</li>
-        </ul>
-      </li>
-      <li><strong>Homekit-bridge</strong> nodes support :
-        <ul>
-          <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
-        </ul>
-        <p>(see:&nbsp;<a title="homekit bridged" href="https://www.npmjs.com/package/node-red-contrib-homekit-bridged" target="_blank" rel="noopener">https://www.npmjs.com/package/node-red-contrib-homekit-bridged</a>) allow managing iOS Home App.</p>
-      </li>
-      <li><strong>MyHome</strong> nodes support :
-        <ul>
-          <li><code>payload</code> being either a boolean (true/false) or a string (ON/OFF/OPEN/CLOSE/...)</li>
-          <li><code>payload</code> being a JSON object where <code>.state</code> is a string (ON/OFF/OPEN/CLOSE/...)</li>
-          <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
-        </ul>
-      </li>
-    </ul>
+  <ul>
+    <li><strong>HUEMagic</strong> nodes support :
+      <ul>
+        <li><code>payload</code> being a boolean (true/false)</li>
+        <li><code>payload</code> being a JSON object where <code>.ON</code> is a boolean (true/false)</li>
+      </ul>
+    </li>
+    <li><strong>Homekit-bridge</strong> nodes support :
+      <ul>
+        <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
+      </ul>
+      <p>(see:&nbsp;<a title="homekit bridged" href="https://www.npmjs.com/package/node-red-contrib-homekit-bridged" target="_blank" rel="noopener">https://www.npmjs.com/package/node-red-contrib-homekit-bridged</a>) allow managing iOS Home App.</p>
+    </li>
+    <li><strong>MyHome</strong> nodes support :
+      <ul>
+        <li><code>payload</code> being either a boolean (true/false) or a string (ON/OFF/OPEN/CLOSE/...)</li>
+        <li><code>payload</code> being a JSON object where <code>.state</code> is a string (ON/OFF/OPEN/CLOSE/...)</li>
+        <li><code>payload</code> being a JSON object where <code>.On</code> is a boolean (true/false)</li>
+      </ul>
+    </li>
+  </ul>
+  <p>
+    <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
+  </p>
+  <p>
+    The <code>msg.mh_nodeConfigInfo</code> contains node configuration values :
+  </p>
+  <ul>
+    <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
+    <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
+    <li> <code>mh_nodeConfigInfo.zoneid</code> <em>[string]</em> : zone ID</li>
+    <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
+  </ul>
 </script>

--- a/locales/en-US/myhome-thermo-zone.html
+++ b/locales/en-US/myhome-thermo-zone.html
@@ -156,7 +156,7 @@
   <ul>
     <li> <code>mh_nodeConfigInfo.name</code> <em>[string]</em> : name</li>
     <li> <code>mh_nodeConfigInfo.topic</code> <em>[string]</em> : topic</li>
-    <li> <code>mh_nodeConfigInfo.zoneid</code> <em>[string]</em> : zone ID</li>
+    <li> <code>mh_nodeConfigInfo.zoneid</code> <em>[string]</em> : zone ID [1-99]</li>
     <li> <code>mh_nodeConfigInfo.gateway</code> <em>[object]</em> : linked gateway info : name (<code>.name</code>), Host/IP (<code>.host</code>) and port (<code>.port</code>)</li>
   </ul>
 </script>

--- a/locales/en-US/myhome-thermo-zone.html
+++ b/locales/en-US/myhome-thermo-zone.html
@@ -147,7 +147,7 @@
     </li>
   </ul>
   <p>
-    <strong>Both outputs</strong> will also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
+    <strong>Both outputs</strong> also include an additional object <code>msg.mh_nodeConfigInfo</code> which includes data from node configuration.
     This can be used in flows to redirect messages based on how (i.e. which node) they come from without having to include 'change nodes' at every stage.
   </p>
   <p>

--- a/myhome-energy.js
+++ b/myhome-energy.js
@@ -28,7 +28,7 @@ module.exports = function (RED) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add listener on node linked to a dedicated function call to be able to remove it on close
-    const listenerFunction = function (frame) {
+    const listenerFunction = function (ownFamilyName , frame) {
       let msg = {};
       node.processReceivedBUSFrames (msg, frame, []);
     };

--- a/myhome-energy.js
+++ b/myhome-energy.js
@@ -235,6 +235,19 @@ module.exports = function (RED) {
           if (!Array.isArray(frame)) {
             payload.command_received = frame;
           }
+          // MSG1 : add major node configuration info on both returned message
+          msg.mh_nodeConfigInfo = {
+            'name' : config.name ,
+            'topic' : config.topic ,
+            'meterid' : config.meterid ,
+            'metertype' : config.metertype ,
+            'meterscope' : config.meterscope ,
+            'gateway' : {
+              'name' : gateway.name ,
+              'host' : gateway.host ,
+              'port' : gateway.port
+            }
+          };
           // MSG1 : Add all current node stored values to payload
           Object.getOwnPropertyNames(payloadInfo).forEach (function(objectName) {
             payload[objectName] = payloadInfo[objectName];

--- a/myhome-eventsession.html
+++ b/myhome-eventsession.html
@@ -12,7 +12,7 @@
       own_energy: { value: true, required: false},
       own_others: { value: false, required: false}
     },
-    outputs: 1,
+    outputs: 2,
     icon: 'font-awesome/fa-rss',
     paletteLabel: 'MH Monitoring',
     label: function() {

--- a/myhome-eventsession.js
+++ b/myhome-eventsession.js
@@ -10,11 +10,29 @@ module.exports = function (RED) {
     let runningMonitor = new mhutils.eventsMonitor (gateway);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Add listener on node linked to a dedicated function call to be able to remove it on close
+    const listenerFunction = function (ownFamilyName , frame) {
+      // MSG1 : add frame received from BUS
+      let msg = {payload: frame};
+      // MSG1 : add major node configuration info
+      msg.mh_nodeConfigInfo = {
+        'name' : config.name ,
+        'ownFamilyName' : ownFamilyName ,
+        'gateway' : {
+          'name' : gateway.name ,
+          'host' : gateway.host ,
+          'port' : gateway.port
+        }
+      };
+      // MSG2 : build secondary output (detailled in 'universal mode')
+      let msg2 = node.processReceivedBUSFrames (msg, ownFamilyName, frame);
+      // Send both outputs
+      node.send ([msg, msg2]);
+    };
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add all listerners on gateway based on types we have to monitor
     // Define the function which is to be called on any triggered command received from the gateway
-    const listenerFunction = function (frame) {
-      node.send ({payload: frame});
-    };
 
     // LIGHTS
     if (config.own_lights) {
@@ -40,6 +58,73 @@ module.exports = function (RED) {
     if (config.own_others) {
       runningMonitor.addMonitoredEvent ('OWN_OTHERS', listenerFunction);
     }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Function called when a MyHome BUS frame is received ///////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    this.processReceivedBUSFrames = function (mainMsg, ownFamilyName, frame) {
+      // Init new msg (cloned from main) & add basinc info on payload (common to all family types)
+      let msg = RED.util.cloneMessage (mainMsg);
+      let payload = msg.payload = {};
+      payload.ownFamilyName = ownFamilyName;
+      payload.command_received = frame;
+
+      // Append content specifc per type
+      let frameMatch;
+      switch (ownFamilyName) {
+        case 'OWN_LIGHTS':
+          // Checks 1 : Light point/group update [*1*<status>|<dimmerLevel10>*where##]
+          //    - <status> [0-1] : 0 = OFF / 1 = ON
+          //    - <dimmerLevel10> [2-10] : 2 = 20% / 3 = 30% / ... / 9 = 90% / 10 = 100%
+          // Note : the RegEx must only keep 2 characters when <status> begins with 1 to skip 30 or 31 since these are dimming UP / DOWN
+          frameMatch = frame.match (/^\*1\*(\d|1\d)\*(#{0,1}\d{1,4})(?:#4#(\d\d)){0,1}##/);
+          // frameMatch[1] = state (0 = off, 1 = on, 2 for 20%, 3 for 30%... 10 for 100%)
+          // frameMatch[2] = lightgroupid (begins with # if is a group)
+          // frameMatch[3] = bus level (01 to 15)
+          if (frameMatch !== null) {
+            payload.state = (frameMatch[1] === '0') ? 'OFF' : 'ON';
+            payload.brightness = (frameMatch[1] === '1') ? 100 : (parseInt(frameMatch[1]) * 10);
+            payload.lightid = frameMatch[2].replace('#' , '');
+            payload.isgroup = (frameMatch[2][0] === '#');
+            payload.buslevel = (frameMatch[3] === undefined) ? 'private_riser' : frameMatch[3];
+          }
+          // Checks 2 : Light point/group dimmer info update [*#1*<where>*1*<dimmerLevel100>*<dimmerSpeed>##]
+          //    - <dimmerLevel100> [100-200] : 100 = off / 200 = Max
+          if (frameMatch === null) {
+            frameMatch = frame.match (/^\*#1\*(#{0,1}\d{1,4})(?:#4#(\d\d)){0,1}\*1\*(\d+)\*\d+##/);
+            // frameMatch[1] = lightgroupid (begins with # if is a group)
+            // frameMatch[2] = bus level (01 to 15)
+            // frameMatch[3] = dimmer level (100 = OFF to 200 = 100%)
+            if (frameMatch !== null) {
+              payload.state = (frameMatch[3] === '100') ? 'OFF' : 'ON';
+              payload.brightness = (parseInt(frameMatch[3]) - 100);
+              payload.lightid = frameMatch[1].replace('#' , '');
+              payload.isgroup = (frameMatch[1][0] === '#');
+              payload.buslevel = (frameMatch[2] === undefined) ? 'private_riser' : frameMatch[2];
+            }
+          }
+          break;
+        case 'OWN_SHUTTERS':
+        	// Nothing managed in 'universal mode' yet
+        	break;
+        case 'OWN_TEMPERATURE':
+        	// Nothing managed in 'universal mode' yet
+        	break;
+        case 'OWN_SCENARIO':
+        	// Nothing managed in 'universal mode' yet
+        	break;
+        case 'OWN_ENERGY':
+        	// Nothing managed in 'universal mode' yet
+        	break;
+        case 'OWN_OTHERS':
+        	// Nothing managed in 'universal mode' yet
+        	break;
+      }
+        // Checks : all done, if one match was successful, it means a 'universal mode' msg was build, return it
+        if (frameMatch !== null) {
+          return msg;
+        }
+    };
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     node.on ('close', function(done)	{

--- a/myhome-eventsession.js
+++ b/myhome-eventsession.js
@@ -106,7 +106,19 @@ module.exports = function (RED) {
           break;
 
         case 'OWN_SHUTTERS':
-        	// Nothing managed in 'universal mode' yet
+            // Checks 1 : Shutter point/group update [*2*<status>*where##]
+            //    - <status> [0-2] : 0 = Stop / 1 = Up / 2 = Down
+          frameMatch = frame.match (/^\*2\*(\d+)\*(#{0,1}\d{1,4})(?:#4#(\d\d)){0,1}##/);
+          // frameMatch[1] = <status> [0-2] : 0 = Stop / 1 = Up / 2 = Down
+          // frameMatch[2] = shuttergroupid (begins with # if is a group)
+          // frameMatch[3] = bus level (01 to 15)
+          if (frameMatch !== null) {
+            payload.buslevel = (frameMatch[3] === undefined) ? 'private_riser' : frameMatch[3];
+            let actionDescr_Shutter = {'0':'STOP', '1':'OPEN', '2':'CLOSE'}[frameMatch[1]];
+            payload.state = (actionDescr_Shutter === undefined) ? '?' : actionDescr_Shutter;
+            payload.shutterid = frameMatch[2].replace('#' , '');
+            payload.isgroup = (frameMatch[2][0] === '#');
+          }
         	break;
 
         case 'OWN_TEMPERATURE':

--- a/myhome-eventsession.js
+++ b/myhome-eventsession.js
@@ -126,7 +126,7 @@ module.exports = function (RED) {
           //  - current temperature (master probe) : *#4*where*0*T## (or *#4*where*0*T*3## if local offset included)
           //    The T field is composed from 4 digits c1c2c3c4, included between “0020” (2°temperature) and “0430” (43°temperature).
           //    c1 is always equal to 0, it indicates a positive temperature. The c2c3 couple indicates the temperature values between [02° - 43°].
-          frameMatch = frame.match (/^\*#4\*(\d{1,3})\*0\*0(\d{3})(?:\*3|)##/);
+          frameMatch = frame.match (/^\*#4\*(\d{1,2})\*0\*0(\d{3})(?:\*3|)##/);
           // frameMatch[1] = <WHERE> [1-99] : zone ID
           // frameMatch[2] = T temperature (193 = 19.3°)
           if (frameMatch !== null) {

--- a/myhome-gateway.js
+++ b/myhome-gateway.js
@@ -119,44 +119,44 @@ module.exports = function (RED) {
       let ownFamily = frame.match (/^\*#{0,1}(\d+)\*.+?##/);
       if (ownFamily !== null) {
         let loggingEnabled = false;
-        let emitterTrigger = "";
+        let ownFamilyName = "";
         if (ownFamily !== null) {
           switch (ownFamily[1]) {
             case '1':
               // WHO = 1 : Lighting
               loggingEnabled = node.log_config.log_in_lights;
-              emitterTrigger = 'OWN_LIGHTS';
+              ownFamilyName = 'OWN_LIGHTS';
               break;
             case '2':
               // WHO = 2 : Automation (Shutters management)
               loggingEnabled = node.log_config.log_in_shutters;
-              emitterTrigger = 'OWN_SHUTTERS';
+              ownFamilyName = 'OWN_SHUTTERS';
               break;
             case '4':
               // WHO = 4 : Temperature Control/Heating
               loggingEnabled = node.log_config.log_in_temperature;
-              emitterTrigger = 'OWN_TEMPERATURE';
+              ownFamilyName = 'OWN_TEMPERATURE';
               break;
             case '15' : case '25' :
               // WHO = 15 (CEN) / 25 (CEN+) : Scenario Management
               loggingEnabled = node.log_config.log_in_scenario;
-              emitterTrigger = 'OWN_SCENARIO';
+              ownFamilyName = 'OWN_SCENARIO';
               break;
             case '18':
               // WHO = 18 : Energy Management
               loggingEnabled = node.log_config.log_in_energy;
-              emitterTrigger = 'OWN_ENERGY';
+              ownFamilyName = 'OWN_ENERGY';
               break;
             default:
               loggingEnabled = node.log_config.log_in_others;
-              emitterTrigger = 'OWN_OTHERS';
+              ownFamilyName = 'OWN_OTHERS';
           }
         }
         if (loggingEnabled) {
-          node.log ("Received OpenWebNet command (" + emitterTrigger + ") : '" + frame + "'");
+          node.log ("Received OpenWebNet command (" + ownFamilyName + ") : '" + frame + "'");
         }
-        if (emitterTrigger !== '') {
-          node.emit (emitterTrigger, frame);
+        if (ownFamilyName !== '') {
+          node.emit (ownFamilyName, ownFamilyName , frame);
         }
       }
     }

--- a/myhome-light.js
+++ b/myhome-light.js
@@ -109,6 +109,19 @@ module.exports = function (RED) {
           if (!Array.isArray(frame)) {
             payload.command_received = frame;
           }
+          // MSG1 : add major node configuration info on both returned message
+          msg.mh_nodeConfigInfo = {
+          	'name' : config.name ,
+          	'topic' : config.topic ,
+          	'buslevel' : config.buslevel ,
+          	'lightid' : config.lightid ,
+          	'isgroup' : config.isgroup ,
+          	'gateway' : {
+          		'name' : gateway.name ,
+          		'host' : gateway.host ,
+          		'port' : gateway.port
+          	}
+          };
           // MSG1 : Add all current node stored values to payload
           payload.state = payloadInfo.state;
           if (payloadInfo.brightness !== undefined) {

--- a/myhome-light.js
+++ b/myhome-light.js
@@ -27,7 +27,7 @@ module.exports = function (RED) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add listener on node linked to a dedicated function call to be able to remove it on close
-    const listenerFunction = function (frame) {
+    const listenerFunction = function (ownFamilyName , frame) {
       let msg = {};
       node.processReceivedBUSFrames (msg, frame);
     };

--- a/myhome-scenario.js
+++ b/myhome-scenario.js
@@ -85,7 +85,7 @@ module.exports = function (RED) {
         // Checks 2 : Advanced scenario (CEN+) [*25*<ACTION_TYPE>#WHAT*WHERE##]
         //    - <ACTION_TYPE> = 21: Short pressure (<0.5s) / 22: Start of extended pressure (>= 0.5s) / 23: Extended pressure (sent every 500ms) / 24: Release after an extended pressure
         //    - WHAT = push button N value [0-31]
-        //    - WHERE = 2 [0-2047] Virtual Address
+        //    - WHERE = 2+[0-2047] Virtual Address
         if (config.scenariotype === 'CEN+') {
           frameMatch = curFrame.match ('^\\*25\\*(\\d{2})#(\\d+)\\*2' + node.scenarioid + '##');
           if (frameMatch !== null) {

--- a/myhome-scenario.js
+++ b/myhome-scenario.js
@@ -207,6 +207,22 @@ module.exports = function (RED) {
           if (!Array.isArray(frame)) {
             payload.command_received = frame;
           }
+          // MSG1 : add major node configuration info on both returned message & spread it to all other multi msg built
+          msg.mh_nodeConfigInfo = {
+            'name' : config.name ,
+            'topic' : config.topic ,
+            'buslevel' : config.buslevel ,
+            'scenariotype' : config.scenariotype ,
+            'scenarioid' : config.scenarioid ,
+            'gateway' : {
+              'name' : gateway.name ,
+              'host' : gateway.host ,
+              'port' : gateway.port
+            }
+          };
+          multiOutput.forEach(function(multiMsg) {
+            multiMsg.mh_nodeConfigInfo = JSON.parse(JSON.stringify(msg.mh_nodeConfigInfo));
+          });
           // MSG1 : Add all current node stored values to payload
           Object.getOwnPropertyNames(payloadInfo).forEach (function(objectName) {
           	if (objectName.match('buttonsLastState_\\d+')) {

--- a/myhome-scenario.js
+++ b/myhome-scenario.js
@@ -27,7 +27,7 @@ module.exports = function (RED) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add listener on node linked to a dedicated function call to be able to remove it on close
-    const listenerFunction = function (frame) {
+    const listenerFunction = function (ownFamilyName , frame) {
       let msg = {};
       node.processReceivedBUSFrames (msg, frame);
     };
@@ -221,7 +221,9 @@ module.exports = function (RED) {
             }
           };
           multiOutput.forEach(function(multiMsg) {
-            multiMsg.mh_nodeConfigInfo = JSON.parse(JSON.stringify(msg.mh_nodeConfigInfo));
+            if (multiMsg !== null) {
+              multiMsg.mh_nodeConfigInfo = JSON.parse(JSON.stringify(msg.mh_nodeConfigInfo));
+            }
           });
           // MSG1 : Add all current node stored values to payload
           Object.getOwnPropertyNames(payloadInfo).forEach (function(objectName) {

--- a/myhome-shutter.js
+++ b/myhome-shutter.js
@@ -91,6 +91,19 @@ module.exports = function (RED) {
           if (!Array.isArray(frame)) {
             payload.command_received = frame;
           }
+          // MSG1 : add major node configuration info on both returned message
+          msg.mh_nodeConfigInfo = {
+          	'name' : config.name ,
+          	'topic' : config.topic ,
+          	'buslevel' : config.buslevel ,
+          	'shutterid' : config.shutterid ,
+          	'isgroup' : config.isgroup ,
+          	'gateway' : {
+          		'name' : gateway.name ,
+          		'host' : gateway.host ,
+          		'port' : gateway.port
+          	}
+          };
           // MSG1 : Add all current node stored values to payload
           payload.state = payloadInfo.state;
           // MSG1 : Add misc info

--- a/myhome-shutter.js
+++ b/myhome-shutter.js
@@ -27,7 +27,7 @@ module.exports = function (RED) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add listener on node linked to a dedicated function call to be able to remove it on close
-    const listenerFunction = function (frame) {
+    const listenerFunction = function (ownFamilyName , frame) {
       let msg = {};
       node.processReceivedBUSFrames (msg, frame);
     };

--- a/myhome-thermo-central.js
+++ b/myhome-thermo-central.js
@@ -166,6 +166,16 @@ module.exports = function (RED) {
           if (!Array.isArray(frame)) {
             payload.command_received = frame;
           }
+          // MSG1 : add major node configuration info on both returned message
+          msg.mh_nodeConfigInfo = {
+            'name' : config.name ,
+            'topic' : config.topic ,
+            'gateway' : {
+              'name' : gateway.name ,
+              'host' : gateway.host ,
+              'port' : gateway.port
+            }
+          };
           // MSG1 : Add all current node stored values to payload
           payload.state = payloadInfo.state;
           payload.remoteControl = payloadInfo.remoteControl;

--- a/myhome-thermo-central.js
+++ b/myhome-thermo-central.js
@@ -25,7 +25,7 @@ module.exports = function (RED) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add listener on node linked to a dedicated function call to be able to remove it on close
-    const listenerFunction = function (frame) {
+    const listenerFunction = function (ownFamilyName , frame) {
       let msg = {};
       node.processReceivedBUSFrames (msg, frame);
     };

--- a/myhome-thermo-zone.js
+++ b/myhome-thermo-zone.js
@@ -205,6 +205,17 @@ module.exports = function (RED) {
           if (!Array.isArray(frame)) {
             payload.command_received = frame;
           }
+          // MSG1 : add major node configuration info on both returned message
+          msg.mh_nodeConfigInfo = {
+            'name' : config.name ,
+            'topic' : config.topic ,
+            'zoneid' : config.zoneid ,
+            'gateway' : {
+              'name' : gateway.name ,
+              'host' : gateway.host ,
+              'port' : gateway.port
+            }
+          };
           // MSG1 : Add all current node stored values to payload
           payload.state = payloadInfo.state;
           payload.setTemperature = payloadInfo.setTemperature;

--- a/myhome-thermo-zone.js
+++ b/myhome-thermo-zone.js
@@ -33,7 +33,7 @@ module.exports = function (RED) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Add listener on node linked to a dedicated function call to be able to remove it on close
-    const listenerFunction = function (frame) {
+    const listenerFunction = function (ownFamilyName , frame) {
       let msg = {};
       node.processReceivedBUSFrames (msg, frame);
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-myhome-bticino-v2",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Control Bticino / Legrand MyHome components from Node-RED",
   "homepage": "https://github.com/FredBlo/node-red-contrib-myhome-bticino-v2#readme",
   "repository": {


### PR DESCRIPTION
### v2.4.0 - 01/2025
- **MH Monitoring**
  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.ownFamilyName` and `.gateway` (object)
  - ***Improvement*** : node has a second output which provides a structured payload object with analyzed information based on BUS received content, as it would be output by a specialized light, shutter,... node. It makes the monitoring node usable as a sort of 'universal node' : all events of one or multiple family types can be processed from a single monitoring node instead of having to add a node for each light, shutter,... point.
  This currently supports (see Monitoring node documentation for full detailed payload content):
    - **Lights** : any light point / group call
    - **Shutters** : any shutter point / group call
    - **Temperature** : only outputs current temperature update for any zone
    - **Scenario** : outputs any button press for CEN/CEN+
    - **Energy** : only outputs current consumption (instant) of any meter
- **MH Light**
  - ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.lightid`, `.isgroup` and `.gateway`*[object]*
- **MH Shutter**
	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.shutterid`, `.isgroup` and `.gateway`*[object]*
- **MH Scenario**
	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.buslevel`, `.scenarioid`, `.scenariotype` and `.gateway`*[object]*
- **MH Temperature Central Unit**
	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic` and `.gateway` *[object]*
- **MH Temperature Zone**
	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.zoneid` and `.gateway` *[object]*
- **MH Energy** :
	- ***Improvement*** : new object included in returned msg (`.mh_nodeConfigInfo`) which contains configuration node info : `.name`, `.topic`, `.meterid`, `.metertype`, `.meterscope` and `.gateway` *[object]*